### PR TITLE
Test New LLMs (Llama2, CodeLlama, etc.) on Chat-UI?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Test New LLMs (CodeLlama, Llama2, etc.) 
+
+Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.
+
+**code**
+```
+$ pip install litellm
+$ litellm --model huggingface/bigcode/starcoder
+#INFO:     Uvicorn running on http://0.0.0.0:8000
+$ aider --openai-api-base http://0.0.0.0:8000
+```
+
+I'd love to know if this solves a problem for you
+
 ---
 title: chat-ui
 emoji: 🔥

--- a/src/lib/components/CopyToClipBoardBtn.svelte
+++ b/src/lib/components/CopyToClipBoardBtn.svelte
@@ -41,6 +41,7 @@
 	"
 	title={"Copy to clipboard"}
 	type="button"
+	on:click
 	on:click={handleClick}
 >
 	<span class="relative">

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -7,6 +7,7 @@
 	import { page } from "$app/stores";
 
 	import CodeBlock from "../CodeBlock.svelte";
+	import CopyToClipBoardBtn from "../CopyToClipBoardBtn.svelte";
 	import IconLoading from "../icons/IconLoading.svelte";
 	import CarbonRotate360 from "~icons/carbon/rotate-360";
 	import CarbonDownload from "~icons/carbon/download";
@@ -58,6 +59,7 @@
 	let contentEl: HTMLElement;
 	let loadingEl: IconLoading;
 	let pendingTimeout: ReturnType<typeof setTimeout>;
+	let isCopied = false;
 
 	const renderer = new marked.Renderer();
 	// For code blocks with simple backticks
@@ -121,6 +123,12 @@
 	$: webSearchSources =
 		searchUpdates &&
 		searchUpdates?.filter(({ messageType }) => messageType === "sources")?.[0]?.sources;
+
+	$: if (isCopied) {
+		setTimeout(() => {
+			isCopied = false;
+		}, 1000);
+	}
 </script>
 
 {#if message.from === "assistant"}
@@ -186,7 +194,7 @@
 			<div
 				class="absolute bottom-1 right-0 flex max-md:transition-all md:bottom-0 md:group-hover:visible md:group-hover:opacity-100
 					{message.score ? 'visible opacity-100' : 'invisible max-md:-translate-y-4 max-md:opacity-0'}
-					{isTapped ? 'max-md:visible max-md:translate-y-0 max-md:opacity-100' : ''}
+					{isTapped || isCopied ? 'max-md:visible max-md:translate-y-0 max-md:opacity-100' : ''}
 				"
 			>
 				<button
@@ -212,6 +220,13 @@
 				>
 					<CarbonThumbsDown class="h-[1.14em] w-[1.14em]" />
 				</button>
+				<CopyToClipBoardBtn
+					on:click={() => {
+						isCopied = true;
+					}}
+					classNames="ml-1.5 !rounded-sm !p-1 !text-sm !text-gray-400 focus:!ring-0 hover:!text-gray-500 dark:!text-gray-400 dark:hover:!text-gray-300 !border-none !shadow-none"
+					value={message.content}
+				/>
 			</div>
 		{/if}
 	</div>


### PR DESCRIPTION
Hi @jcalebsmith,

Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.

**code**
```
$ pip install litellm

$ litellm --model huggingface/bigcode/starcoder

#INFO:     Uvicorn running on http://0.0.0.0:8000

$ aider --openai-api-base http://0.0.0.0:8000
```

I'd love to know if this solves a problem for you